### PR TITLE
fix:文字タイトルのはみ出しを抑制

### DIFF
--- a/src/user/components/Top/SystemCard.tsx
+++ b/src/user/components/Top/SystemCard.tsx
@@ -24,6 +24,9 @@ const StyledSystemCard = styled.li`
 const SystemTitle = styled.h4`
     margin: 0 0 8px 0;
     font-size: $H2;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 `
 
 const SystemRegion = styled.p`


### PR DESCRIPTION
close #194 
![image](https://user-images.githubusercontent.com/31458031/64942471-14665e00-d8a4-11e9-9146-195a4da52db9.png)
